### PR TITLE
fix session weight for memcache

### DIFF
--- a/src/Provider/SessionServiceProvider.php
+++ b/src/Provider/SessionServiceProvider.php
@@ -238,7 +238,7 @@ class SessionServiceProvider implements ServiceProviderInterface
                         $conn['host'] ?: 'localhost',
                         $conn['port'] ?: 11211,
                         $conn['persistent'] ?: false,
-                        $conn['weight'] ?: 0,
+                        $conn['weight'] ?: 1,
                         $conn['timeout'] ?: 1
                     );
                 }


### PR DESCRIPTION
fix session weight for memcache.
old default value 0 don't work on php5.6 
## Details

fix bug https://github.com/bolt/bolt/issues/5855
